### PR TITLE
get jQuery over HTTPS

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -47,7 +47,7 @@
     </div>
 
 
-    <script src="http://code.jquery.com/jquery.js"></script>
+    <script src="https://code.jquery.com/jquery.js"></script>
     <script src="{% static "js/bootstrap.min.js" %}"></script>
 
 </body>


### PR DESCRIPTION
This makes the HTTPS everywhere extension not throw a fit and refuse to load jQuery when you access blaggregator over HTTPS.
