### PR TITLE
Reduce name collisions by adding last name

### DIFF
--- a/home/management/commands/crawlposts.py
+++ b/home/management/commands/crawlposts.py
@@ -120,7 +120,7 @@ def send_message_humbug(user, link, title):
     data = {"type": "stream",
             "to": "%s" % STREAM,
             "subject": subject,
-            "content": "**%s** has a new blog post: [%s](%s)" % (user.first_name, title, url),
+            "content": "**%s %s** has a new blog post: [%s](%s)" % (user.first_name, user.last_name, title, url),
         }
     print data['content']
     r = requests.post('https://humbughq-com-y3ee336dh1kn.runscope.net/api/v1/messages', data=data, auth=(email, key))


### PR DESCRIPTION
There are now enough people posting nowadays that I'm not always sure whose post it is from the first name alone.

I actually like how it sounds with only the first name in the announcement, so I'm not sure this is a net win; that's up to you to decide :-).
