### PR TITLE
Clean up topic names

### DIFF
--- a/home/management/commands/crawlposts.py
+++ b/home/management/commands/crawlposts.py
@@ -118,8 +118,9 @@ def cleantitle(title):
 
 def send_message_zulip(user, link, title):
 
-    subject = "new blog post: %s" % title
-    subject = subject[:57] + "..."
+    subject = title
+    if len(subject) > 60:
+        subject = subject[:57] + "..."
     
     # add a trailing slash if it's not already there (jankily)
     if link[-1] != '/': link = link + '/'


### PR DESCRIPTION
Now that Blaggregator posts to the "blogging" stream, the "new blog post:" text in the topic is unnecessary, and it's easier to find Zulip discussions without it. This patch removes the redundant text.
