### PR TITLE
Use /people/me instead of /people/me.json

### DIFF
--- a/home/oauth.py
+++ b/home/oauth.py
@@ -114,7 +114,7 @@ class HackerSchoolOAuth2(BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data."""
-        url = self.HACKER_SCHOOL_ROOT + '/api/v1/people/me.json?' + urlencode({
+        url = self.HACKER_SCHOOL_ROOT + '/api/v1/people/me?' + urlencode({
              'access_token': access_token
         })
         try:


### PR DESCRIPTION
/people/me is the official API endpoint. I'd like to remove support for having a file format (.json) in our api urls because of some other problems it's causing. Blaggregator is the only app using *.json and that's because I mistakenly told you to use it. I'm fixing my error now :)
