### PR TITLE
Get rid of unnecessary redirects

### DIFF
--- a/home/management/commands/crawlposts.py
+++ b/home/management/commands/crawlposts.py
@@ -16,7 +16,7 @@ from home import feedergrabber27
 
 log = logging.getLogger("blaggregator")
 
-ROOT_URL = 'http://www.blaggregator.us/'
+ROOT_URL = 'https://blaggregator.recurse.com/'
 
 STREAM = 'blogging'
 MAX_POST_ANNOUNCE = 2

--- a/home/middleware.py
+++ b/home/middleware.py
@@ -4,7 +4,7 @@ from django import http
 class RecurseSubdomainMiddleware(object):
     """Middleware to redirect all users to recurse subdomain."""
 
-    REDIRECTS = {
+    HTTPS_REDIRECTS = {
         'blaggregator.us': 'blaggregator.recurse.com',
         'www.blaggregator.us': 'blaggregator.recurse.com',
     }
@@ -13,7 +13,7 @@ class RecurseSubdomainMiddleware(object):
         """Check for old HTTP_HOST and redirect to recurse subdomain."""
 
         host = request.get_host()
-        if host in self.REDIRECTS:
-            request.META['HTTP_HOST'] = self.REDIRECTS[host]
-            newurl = request.build_absolute_uri()
+        if host in self.HTTPS_REDIRECTS:
+            request.META['HTTP_HOST'] = self.HTTPS_REDIRECTS[host]
+            newurl = request.build_absolute_uri().replace('http://', 'https://')
             return http.HttpResponsePermanentRedirect(newurl)

--- a/home/urls.py
+++ b/home/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import include, patterns, url
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
 from home import views
 
-urlpatterns = patterns('',
-    url(r'^$', lambda x: HttpResponseRedirect('/new')),
+urlpatterns = patterns(
+    '',  # prefix
+    url(r'^$', lambda x: HttpResponseRedirect(reverse('new'))),
     url(r'^login/$', views.log_in_oauth),
     url(r'^profile/(?P<user_id>\d+)/$', views.profile, name='profile'),
     url(r'^new/$', views.new, name='new'),


### PR DESCRIPTION
- Change URLs posted to Zulip to be direct URLs
- Redirect to the https site in the middleware
- Redirect to `/new/` from `/` instead of going via `/new`