### PR TITLE
Add RC Scout links to add blog page

### DIFF
--- a/home/templates/home/add_blog.html
+++ b/home/templates/home/add_blog.html
@@ -1,5 +1,7 @@
 {% load customtags %}
-
+{% if forms %}
+    <div class="pb-3">Consider adding <a href="https://www.recurse.com/settings/scout" target="_blank" rel="noopener noreferrer">RC Scout</a> to your blog to help drive traffic to RC.</div>
+{% endif %}
 <div class="card bg-default">
     {% if forms %}
         <button type="button"
@@ -23,6 +25,7 @@
             <li>All your <strong>future</strong> blog posts (in this feed) will be notified on Zulip in
                 <a href="{{ ""|zulip_url:"blogging" }}" target="_blank">#blogging</a>
             </li>
+            <li>Consider adding <a href="https://www.recurse.com/settings/scout" target="_blank" rel="noopener noreferrer">RC Scout</a> to your blog to help drive traffic to RC.</li>
         </ul>
     </div>
     <div class="card-footer add-blog {% if forms and not messages %}collapse{% endif %}">


### PR DESCRIPTION
This adds links to RC Scout, encouraging people to add it to their blog, as I believe @nicholasbs discussed with you @punchagan. Here's what it looks like before you've added a blog:

![Screenshot 2024-12-13 at 12 21 35 PM](https://github.com/user-attachments/assets/39961a22-bfa1-407e-9034-86451d39b17e)

and after:

![Screenshot 2024-12-13 at 12 22 01 PM](https://github.com/user-attachments/assets/e253009a-efee-445e-91f3-b0212c39f1e7)

Let me know if that looks good to you both @nicholasbs @punchagan. Happy to make style of copy tweaks!
